### PR TITLE
4.1.5 Реализует подписки внутри компонентов Подписки необходимы, чтобы перестать напрямую использовать метод "addEventListener" из-за которого в файле main.js нам нужно знать внутреннее устройство представления, что плохо.  - Скроем addEventListener за интерфейсом компонента: в карточке задачи, в форме редактирования и кнопках - Колбэк передадим через абстракцию - внутренний метод-обработчик

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import FilmsPresenter from './presenter/films-presenter.js';
 import FilmsModel from './model/films-model.js';
 import CommentsModel from './model/comments-model.js';
 
-import { render } from './render.js';
+import { render } from './framework/render.js';
 
 //import { generateFilms } from './mock/film';
 //import { generateComments } from './mock/comment';

--- a/src/presenter/films-presenter.js
+++ b/src/presenter/films-presenter.js
@@ -6,7 +6,7 @@ import FilmButtonMoreView from '../view/film-button-more-view.js';
 import FilmCardView from '../view/film-card-view.js';
 import FilmDetailsView from '../view/film-details-view.js';
 import NoFilmView from '../view/no-film-view.js';
-import { render } from '../render.js';
+import { render } from '../framework/render.js';
 import { FILM_COUNT_PER_STEP } from '../const.js';
 
 

--- a/src/presenter/films-presenter.js
+++ b/src/presenter/films-presenter.js
@@ -70,16 +70,14 @@ export default class FilmsPresenter {
     if (this.#films.length > FILM_COUNT_PER_STEP) {
       render(this.#filmButtonMoreComponent, this.#filmListComponent.element);
 
-      this.#filmButtonMoreComponent.element.addEventListener('click', this.#handleFilmButtonMoreComponentClick);
+      this.#filmButtonMoreComponent.setButtonMoreClickHandler(this.#filmButtonMoreClickHandler);
     }
   }
 
   #renderFilm = (film, container) => {
     const filmCardComponent = new FilmCardView(film);
 
-    const linkFilmCardElement = filmCardComponent.element.querySelector('a');
-
-    linkFilmCardElement.addEventListener('click', () => {
+    filmCardComponent.setCardClickHandler(() => {
       this.#addFilmDetailsComponent(film);
       document.addEventListener('keydown', this.#onEscKeyDown);
     });
@@ -91,9 +89,7 @@ export default class FilmsPresenter {
     const comments = [...this.#commentsModel.get(film)];
     this.#filmDetailsComponent = new FilmDetailsView(film, comments);
 
-    const closeButtonFilmDetailsElement = this.#filmDetailsComponent.element.querySelector('.film-details__close-btn');
-
-    closeButtonFilmDetailsElement.addEventListener('click', () => {
+    this.#filmDetailsComponent.setCloseButtonHandler(() => {
       this.#removeFilmDetailsComponent();
       document.removeEventListener('keydown', this.#onEscKeyDown);
     });
@@ -121,8 +117,7 @@ export default class FilmsPresenter {
   };
 
   //- По клику будем допоказывать задачи, опираясь на счётчик
-  #handleFilmButtonMoreComponentClick = (evt) => {
-    evt.preventDefault();
+  #filmButtonMoreClickHandler = () => {
     this.#films.slice(this.#renderedFilmCount, this.#renderedFilmCount + FILM_COUNT_PER_STEP)
       .forEach((film) => this.#renderFilm(film, this.#filmListContainerComponent));
 

--- a/src/view/film-button-more-view.js
+++ b/src/view/film-button-more-view.js
@@ -6,4 +6,22 @@ export default class FilmButtonMoreView extends AbstractView {
   get template() {
     return createFilmButtonMoreTemplate();
   }
+
+  setButtonMoreClickHandler = (callback) => {
+    // Мы могли бы сразу передать callback в addEventListener,
+    // но тогда бы для удаления обработчика в будущем,
+    // нам нужно было бы производить это снаружи, где-то там,Add commentMore actions
+    // где мы вызывали setClickHandler, что не всегда удобно
+
+    // 1. Поэтому колбэк мы запишем во внутреннее свойство
+    this._callback.click = callback;
+    // 2. В addEventListener передадим абстрактный обработчик
+    this.element.addEventListener('click', this.#clickHandler);
+  };
+
+  #clickHandler = (evt) => {
+    evt.preventDefault();
+    // 3. А внутри абстрактного обработчика вызовем колбэк
+    this._callback.click();
+  };
 }

--- a/src/view/film-card-view.js
+++ b/src/view/film-card-view.js
@@ -1,4 +1,4 @@
-import { createElement } from '../render.js';
+import AbstractView from '../framework/view/abstract-view.js';
 import { createFilmCardControlsTemplate } from './film-card-controls-template.js';
 import { createFilmCardInfoTemplate } from './film-card-info-template.js';
 
@@ -10,27 +10,15 @@ const createFilmCardTemplate = ({ filmInfo, comments }) =>
     </article>
   `;
 
-export default class FilmCardView {
-  #element = null;
+export default class FilmCardView extends AbstractView {
   #film = null;
 
   constructor(film) {
+    super();
     this.#film = film;
   }
 
   get template() {
     return createFilmCardTemplate(this.#film);
-  }
-
-  get element() {
-    if (!this.#element) {
-      this.#element = createElement(this.template);
-    }
-
-    return this.#element;
-  }
-
-  removeElement() {
-    this.#element = null;
   }
 }

--- a/src/view/film-card-view.js
+++ b/src/view/film-card-view.js
@@ -21,4 +21,14 @@ export default class FilmCardView extends AbstractView {
   get template() {
     return createFilmCardTemplate(this.#film);
   }
+
+  setCardClickHandler = (callback) => {
+    this._callback.cardClick = callback;
+    this.element.querySelector('a').addEventListener('click', this.#cardClickHandler);
+  };
+
+  #cardClickHandler = (evt) => {
+    evt.preventDefault();
+    this._callback.cardClick();
+  };
 }

--- a/src/view/film-details-view.js
+++ b/src/view/film-details-view.js
@@ -38,4 +38,14 @@ export default class FilmDetailsView extends AbstractView {
   get template() {
     return createFilmDetailsTemplate(this.#film, this.#comments);
   }
+
+  setCloseButtonHandler = (callback) => {
+    this._callback.closeButtonClick = callback;
+    this.element.querySelector('.film-details__close-btn').addEventListener('click', this.#closeButtonClickHandler);
+  };
+
+  #closeButtonClickHandler = (evt) => {
+    evt.preventDefault();
+    this._callback.closeButtonClick();
+  };
 }

--- a/src/view/film-details-view.js
+++ b/src/view/film-details-view.js
@@ -1,4 +1,4 @@
-import { createElement } from '../render.js';
+import AbstractView from '../framework/view/abstract-view.js';
 import { createFilmDetailsCommentsTemplate } from './film-details-comments-template.js';
 import { createFilmDetailsControlsTemplate } from './film-details-controls-template.js';
 import { createFilmDetailsFormTemplate } from './film-details-form-template.js';
@@ -25,29 +25,17 @@ const createFilmDetailsTemplate = ({ filmInfo }, comments) => `
   </section>
 `;
 
-export default class FilmDetailsView {
-  #element = null;
+export default class FilmDetailsView extends AbstractView {
   #film = null;
   #comments = null;
 
   constructor(film, comments) {
+    super();
     this.#film = film;
     this.#comments = comments;
   }
 
   get template() {
     return createFilmDetailsTemplate(this.#film, this.#comments);
-  }
-
-  get element() {
-    if (!this.#element) {
-      this.#element = createElement(this.template);
-    }
-
-    return this.#element;
-  }
-
-  removeElement() {
-    this.#element = null;
   }
 }


### PR DESCRIPTION
Ещё раз проверьте, что во View, которые получают информацию снаружи, объявлен метод constructor, а внутри вызвана служебная функция super(). В конце, чтобы убедиться, что всё сделано правильно, запустите проект локально. Он должен сохранить свою полную работоспособность после всех ваших манипуляций.

На этом шаге мы максимально отойдём от работы с DOM в Presenter в сторону работы с методами View. Начнём с подписок на события.

Добавьте во View методы для установки обработчиков событий и перенесите туда код addEventListener из Presenter. Глобальные обработчики — на document и window — пока оставьте как есть. В Presenter вместо addEventListener используйте методы View для установки обработчиков.

Обратите внимание, что подписки нужно реализовывать через защищённое свойство-прослойку _callback, чтобы после мы смогли реализовать механизм отписки от событий. Как работать с _callback подглядывайте в демо-проекте.

Теперь Presenter ничего не знает о внутреннем устройстве компонентов, DOM и событиях. Мы можем менять разметку, добавлять или удалять обработчики безболезненно для всего приложения. Главное, сохранять интерфейс компонентов.